### PR TITLE
Add version not implemented notification

### DIFF
--- a/kernel/osdriver/src/loader.c
+++ b/kernel/osdriver/src/loader.c
@@ -3,6 +3,11 @@
 /* Start of our code */
 void _start()
 {
+	if(KERN_SYSCALL_TBL == 0)
+	{
+		OSFatal("Version not implemented!");
+	}
+	
 	/* Load a good stack */
 	asm(
 		"lis %r1, 0x1ab5 ;"

--- a/kernel/osdriver/src/loader.c
+++ b/kernel/osdriver/src/loader.c
@@ -6,7 +6,7 @@ void _start()
 	*/ Notify the user if the kernel version is not implemented */
 	if(KERN_SYSCALL_TBL == 0)
 	{
-		OSFatal("Version not implemented!");
+		OSFatal("Your kernel version has not been implemented yet");
 	}
 	
 	/* Load a good stack */

--- a/kernel/osdriver/src/loader.c
+++ b/kernel/osdriver/src/loader.c
@@ -3,6 +3,7 @@
 /* Start of our code */
 void _start()
 {
+	*/Notify the user if the kernel version is not implemented*/
 	if(KERN_SYSCALL_TBL == 0)
 	{
 		OSFatal("Version not implemented!");

--- a/kernel/osdriver/src/loader.c
+++ b/kernel/osdriver/src/loader.c
@@ -3,7 +3,7 @@
 /* Start of our code */
 void _start()
 {
-	*/Notify the user if the kernel version is not implemented*/
+	*/ Notify the user if the kernel version is not implemented */
 	if(KERN_SYSCALL_TBL == 0)
 	{
 		OSFatal("Version not implemented!");

--- a/kernel/osdriver/src/loader.c
+++ b/kernel/osdriver/src/loader.c
@@ -3,7 +3,7 @@
 /* Start of our code */
 void _start()
 {
-	*/ Notify the user if the kernel version is not implemented */
+	/* Notify the user if the kernel version is not implemented */
 	if(KERN_SYSCALL_TBL == 0)
 	{
 		OSFatal("Your kernel version has not been implemented yet");


### PR DESCRIPTION
Users with Wii U firmware versions where the kernel exploit is not implemented on are not notified. Instead of freezing or getting "Race attack failed :(" a more appropriate message should be displayed. I added code that does this.
