### PR TITLE
Fix osdriver exploit building on *NIX

### DIFF
--- a/kernel/osdriver/Makefile
+++ b/kernel/osdriver/Makefile
@@ -1,10 +1,9 @@
 CC=powerpc-eabi-gcc
-CFLAGS=-std=gnu99 -nostdinc -fno-builtin -c
+CFLAGS=-nostdinc -fno-builtin -c
 LD=powerpc-eabi-ld
 LDFLAGS=-Ttext 1800000 --oformat binary
 project	:=	src
-override CURDIR:=$(shell cygpath -m $(CURDIR))
-root:=$(CURDIR)
+root:=.
 build	:=	 $(root)/bin
 libs := $(root)/../../libwiiu/bin
 www :=$(root)/../../www


### PR DESCRIPTION
I simply replaced the Makefile with one from an example and I can now build the exploit on Ubuntu. Please test it on Windows with Cygwin too.
Fixes issue #20 without merging PR #18.
