### PR TITLE
OSDriver exploit improvement

### DIFF
--- a/kernel/osdriver/Makefile
+++ b/kernel/osdriver/Makefile
@@ -1,9 +1,9 @@
 PATH		:=	$(DEVKITPPC)/bin:$(PATH)
 PREFIX		=	powerpc-eabi-
 CC			=	$(PREFIX)gcc
-CFLAGS		=	-std=gnu99 -nostdinc -fno-builtin -c
+CFLAGS		=	-std=gnu99 -nostdinc -fno-builtin -fno-toplevel-reorder -c -Os
 LD			=	$(PREFIX)ld
-LDFLAGS		=	-Ttext 1800000 --oformat binary
+LDFLAGS		=	-Ttext 1800000 --oformat binary -L$(DEVKITPPC)/lib/gcc/powerpc-eabi/4.8.2 -lgcc
 project		:=	src
 root		:=	.
 build		:=	$(root)/bin
@@ -16,61 +16,38 @@ all: setup main532 main500 main410 main400 main310 main300 main210 main200
 setup:
 	mkdir -p $(root)/bin/
 
+main540:
+	make main FIRMWARE=532
+
 main532:
-	$(CC) $(CFLAGS) -DVER=532 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code532.bin $(build)/loader.o $(libs)/532/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=532
 
 main500:
-	$(CC) $(CFLAGS) -DVER=500 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code500.bin $(build)/loader.o $(libs)/500/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=500
 
 main410:
-	$(CC) $(CFLAGS) -DVER=410 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code410.bin $(build)/loader.o $(libs)/410/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=410
 
 main400:
-	$(CC) $(CFLAGS) -DVER=400 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code400.bin $(build)/loader.o $(libs)/400/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=400
 
 main310:
-	$(CC) $(CFLAGS) -DVER=310 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code310.bin $(build)/loader.o $(libs)/310/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=310
 
 main300:
-	$(CC) $(CFLAGS) -DVER=300 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code300.bin $(build)/loader.o $(libs)/300/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=300
 
 main210:
-	$(CC) $(CFLAGS) -DVER=210 $(project)/*.c
-	#-Wa,-a,-ad
-	cp -r $(root)/*.o $(build)
-	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code210.bin $(build)/loader.o $(libs)/210/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	make main FIRMWARE=210
 
 main200:
-	$(CC) $(CFLAGS) -DVER=200 $(project)/*.c
-	#-Wa,-a,-ad
+	make main FIRMWARE=200
+
+main:
+	$(CC) $(CFLAGS) -DVER=$(FIRMWARE) $(project)/*.c
 	cp -r $(root)/*.o $(build)
 	rm $(root)/*.o
-	$(LD) $(LDFLAGS) -o $(build)/code200.bin $(build)/loader.o $(libs)/200/*.o `find $(build) -name "*.o" ! -name "loader.o"`
+	$(LD) -o $(build)/code$(FIRMWARE).bin $(build)/loader.o $(libs)/$(FIRMWARE)/*.o `find $(build) -name "*.o" ! -name "loader.o"` $(LDFLAGS)
 
 clean:
 	rm -r $(build)/*

--- a/kernel/osdriver/src/loader.h
+++ b/kernel/osdriver/src/loader.h
@@ -81,13 +81,11 @@
 
 void _start();
 
-void _entryPoint();
-
 /* Find a ROP gadget by a sequence of bytes */
 void *find_gadget(uint32_t code[], uint32_t length, uint32_t gadgets_start);
 
 /* Arbitrary read and write syscalls */
-uint32_t kern_read(const void *addr);
-void kern_write(void *addr, uint32_t value);
+uint32_t __attribute__ ((noinline)) kern_read(const void *addr);
+void __attribute__ ((noinline)) kern_write(void *addr, uint32_t value);
 
 #endif /* LOADER_H */


### PR DESCRIPTION
As MN1 asked me to create a pull request for it, here it is. I did a few points on the osdriver exploit. One is the use of code optimizations for size with correct compile options to allow that. The main change is the improvement of the osdriver exploit success rate. This was tested on several firmwares by several people now and confirmed to be an improvement of the success rate. The main idea is to block the core 1 on a context switch with a few instructions while core 0 and 2 are doing the job. With a thread yield we jump back to the original context after a short delay with a few instructions. This probably can be improved even more by playing a little more with the values. I didnt have time to try all kind of value combinations to actually get 100% stability. I found a few values pretty quick which give very good results and thats where I stopped.

here is my changelist:
- compile with -Os optimizations
- clean up Makefile to re-use parts for all firmwares
- improved osdriver timing hit
